### PR TITLE
README: What's new 加 emoji，09-05 / 09-04 条目收成一句话（中英同步）

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,42 +28,29 @@
 
 **2026-09-05**
 
-- **素材呈现拓展：10 张新卡（79 → 89）**——从 47 张实验室原型里经用户两轮筛选留 21 张，再按"它到底是什么"收成 10 张卡 + 4 段规则：
-  `parallel-items-with-host` 并列句排版（人物在场，七种版式一卡切换）· `still-layout-relay` 一主两辅 / 三联画焦点接力 · `split-compare-slider` 对比双分屏 ·
-  `filmstrip-conveyor` 传送带列举 · `grid-to-hero` 网格收成主角 · `stack-fan-out` 卡堆扇开 · `split-60-40-story` 60/40 主从分屏 · `multi-still-tour` 照片墙 / 时间线巡览停靠 ·
-  `bed-echo-blur` 同源模糊底床 · `rack-focus-pair` 焦点接力。每张卡 md 开头新增**「输入类型」**（口播人物 / B-roll 视频 / 图片 各写可否）与**「常用场景」**四条，
-  taxonomy 新增全库「输入类型索引」——选卡先按这一镜的素材类型过滤。规则四段：实拍底床处理链（design-language §1.2）、多素材同屏"关系 → 版式"表（shot-design §2④′）、
-  并列句三纪律（layout §7.1）、**字与画同起同收**（持续运动写速率不写秒数、时长 = 镜头时长，不留"字没了画面还在"的尾巴）。
-- **排版规范 `references/layout.md`**——用户审片抓出的 10 处缺陷全是排版（贴边、色块与标题不对齐、取景框没套住字、独句缩在角落、条目字太小、图组不居中、间距倒挂、黑字压邻列、章节卡同色）。
-  借三套版式 skill 的共通范式定下：12 栏栅格吸附、间距令牌且外边距 ≥ 组间距 ≥ 组内间距、字形边对齐、无人物时组包围盒居中、标注几何实测反推、
-  字阶最小档（条目 ≥40 / 独句 hero）、包围盒不相交、同组底板淡色系、章节卡按章换色、定妆帧开 debugOverlay 核九项。
-  **选卡必读卡经验**：选中的卡的「已知坑」「落位自检」逐条抄进 SHOTBOOK 自检列。
-- **12 款动态幕底入库**——`template/motion-systems/backdrop.tsx`（深 6 / 浅 6，GLSL / Canvas / CSS 三路线，frame 驱动零随机，默认 1.5×，静态噪点抗色带）；
-  design-language §1.1 背景菜单重写，默认幕底改为浅 `pastel-mesh-flow` / 深 `mesh-flow-dark`。
+- 🧩 **10 张多素材同屏新卡（79 → 89）**——并列句排版、三联画接力、对比分屏、传送带、卡堆扇开等，每卡标注输入类型与常用场景，选卡先按素材类型过滤（→ `references/taxonomy.md` 输入类型索引）。
+- 📐 **排版规范 `references/layout.md`**——12 栏栅格、间距令牌、字阶最小档、包围盒不相交等九项自检，选中卡的「已知坑 / 落位自检」必须抄进 SHOTBOOK。
+- 🎨 **12 款动态幕底入库**——`template/motion-systems/backdrop.tsx` 深浅各 6 款、frame 驱动零随机，默认幕底改为浅 `pastel-mesh-flow` / 深 `mesh-flow-dark`。
 
 **2026-09-04**
 
-- **运动系统做减法**——口播视频只保留每场景一条极缓推进 / 拉出的相机曲线 + 让位；主体 idle 微动、环境呼吸 vignette / 扫光 /
-  曝光脉冲、相机重音脉冲、x/y/旋转/模糊曲线不再要求（模板代码保留能力、默认关闭）。静息帧口径从"≥2 层在动"改为"相机在动"。
-- **网页拍摄不贴图**——调研中判定可用的网页，成片里不再以静态截图贴屏，而是被镜头"拍"：匀速滚动
-  （`evidence-scroll-tour`）、兴趣点巡游（`stage-keyframe-tour`）、局部放大镜 / 画中画（`magnifier-detail` / `pip-zoom-box`）、
-  荧光笔与墨线划重点（`highlighter-sweep` / `ink-underline`）。素材采集定为 Playwright 全页 2× 长图 + 同会话 DOM 实测坐标 JSON，
-  放大与划线全吃实测坐标。→ SKILL.md §③、`references/shot-design.md` §2④、`references/broll-sources.md`
+- 🎥 **运动系统做减法**——每场景只保留一条极缓推拉相机曲线 + 让位，idle 微动 / 环境呼吸 / 脉冲全部默认关闭。
+- 🌐 **网页拍摄不贴图**——网页素材不再静态贴屏，改为镜头滚动 / 巡游 / 放大镜 / 划重点"拍"出来，坐标全吃 Playwright 实测（→ SKILL.md §③、`references/shot-design.md` §2④）。
 
 **2026-09-02**
 
-- **动效工作台 `workbench/`**——剪映式的成片后期台：多轨时间线 + 素材库（素材 / 动效库 / 音效 / 背景）+
+- 🎛️ **动效工作台 `workbench/`**——剪映式的成片后期台：多轨时间线 + 素材库（素材 / 动效库 / 音效 / 背景）+
   schema 属性面板 + 实时预览 + 一键「导出成片」。89 张动效卡 100% 参数化（文案 / 颜色 / 字号 / 位置可调，
   节奏命门固定不暴露）；口播成片可一键拆成字幕 / 转场 / 环境 / 数字人 / 镜头 / 配音 / 音效七类多轨单元逐项微调。
   skill 交付成片后会主动打开它。→ [**图文指南 workbench/GUIDE.md**](workbench/GUIDE.md)
 
   <a href="workbench/GUIDE.md"><img src="workbench/docs/img/01-overview.png" alt="动效工作台总览" width="720"></a>
 
-- **渲染提速：分段渲染母版制**——`scripts/render_shots.mjs` 按镜头切段并行渲、段内单进程保光栅一致，
+- ⚡ **渲染提速：分段渲染母版制**——`scripts/render_shots.mjs` 按镜头切段并行渲、段内单进程保光栅一致，
   拼装 + 整条音轨混入 + 帧数断言；改一个镜头只重渲该段±邻段。`scripts/render_stills.mjs` 一次 bundle 批量出静帧。
-- **评审 token 减量**——`scripts/contact_sheet.py` 把 QA 帧拼成 3×4 网格给评审子代理整版浏览；连拍三帧对只对标了
+- 🧮 **评审 token 减量**——`scripts/contact_sheet.py` 把 QA 帧拼成 3×4 网格给评审子代理整版浏览；连拍三帧对只对标了
   `"burst": true` 的状态切换锚点抽（曾占评审材料 2/3）。
-- **一轮审片即交付**——机器闸全过后只做 1 轮独立审片、修完 P0/P1 即交付，再询问是否续审（累计封顶 3 轮），
+- ✅ **一轮审片即交付**——机器闸全过后只做 1 轮独立审片、修完 P0/P1 即交付，再询问是否续审（累计封顶 3 轮），
   替代旧的"循环到全过"。
 
 | 实测（201s 竖屏片） | 之前 | 现在 |
@@ -73,7 +60,7 @@
 | 43 张静帧抽样 | 11 min | ~1 min |
 | 评审读 160 张 QA 帧 | ≈16 万 token / 21 min | ≈4 万 token / 7 min（拼图） |
 
-- 新卡：社区贡献 **douyin-follow-card 抖音主页关注卡**（[@scpcn01vision-oss](https://github.com/scpcn01vision-oss)），库存 79 张。
+- 🤝 新卡：社区贡献 **douyin-follow-card 抖音主页关注卡**（[@scpcn01vision-oss](https://github.com/scpcn01vision-oss)），库存 79 张。
 
 ## ✨ 亮点
 

--- a/README_EN.md
+++ b/README_EN.md
@@ -34,37 +34,18 @@ camera moves, plain-cut subtitles, and film-grade SFX, all locked to the voice.
 
 **2026-09-05**
 
-- **Material presentation expansion: 10 new cards (79 → 89)** — 47 lab prototypes went through two rounds of user review down to 21, then folded by "what it really is" into 10 cards + 4 rules:
-  `parallel-items-with-host` (parallel-sentence layouts with the presenter on camera, seven layouts on one card) · `still-layout-relay` (hero-duo / triptych with focus relay) · `split-compare-slider` ·
-  `filmstrip-conveyor` · `grid-to-hero` · `stack-fan-out` · `split-60-40-story` · `multi-still-tour` (photo wall / timeline dolly with stops) · `bed-echo-blur` (same-source blur bed) · `rack-focus-pair`.
-  Every new card's md opens with an **input-type table** (presenter video / B-roll / images) and **four common scenarios**; taxonomy gains a library-wide **input-type index** so card selection
-  starts by filtering on the shot's material. Four rules: the live-footage bed processing chain (design-language §1.2), the multi-asset "relationship → layout" table (shot-design §2④′),
-  the three parallel-sentence disciplines (layout §7.1), and **text and picture end together** (continuous motion is written as a rate, duration = shot length, no tail where the words are gone but the bed keeps drifting).
-- **Layout spec `references/layout.md`** — a review of one delivered video surfaced 10 defects, all layout: edge-hugging cards, block/title
-  misalignment, a bracket frame missing its text, a lone sentence shrunk into a corner, tiny list items, off-center groups, inverted spacing,
-  text colliding with a neighbouring column, same-colour chapter cards. Borrowing the shared patterns of three slide/card skills: 12-column grid
-  snapping, spacing tokens with margin ≥ group gap ≥ inner gap, glyph-edge alignment, centred bounding boxes, measured annotation geometry,
-  minimum type sizes (list items ≥40 / lone sentence = hero), no overlapping boxes, pastel-differentiated chips, per-chapter colours, a 9-point
-  check on debug-overlay stills. **Card experience is mandatory reading**: every chosen card's pitfalls / placement checks go into the SHOTBOOK.
-- **12 dynamic backdrops shipped** — `template/motion-systems/backdrop.tsx` (6 dark / 6 light; GLSL / Canvas / CSS, frame-driven, zero randomness,
-  default 1.5× speed, static grain against banding); design-language §1.1 rewritten, defaults are light `pastel-mesh-flow` / dark `mesh-flow-dark`.
+- 🧩 **10 new multi-asset cards (79 → 89)** — parallel-sentence layouts, triptych relay, compare slider, filmstrip, stack fan-out and more; every card lists its input types and common scenarios, so card selection starts by filtering on the shot's material (→ input-type index in `references/taxonomy.md`).
+- 📐 **Layout spec `references/layout.md`** — 12-column grid, spacing tokens, minimum type sizes, non-overlapping boxes and a 9-point still check; each chosen card's pitfalls / placement checks must be copied into the SHOTBOOK.
+- 🎨 **12 dynamic backdrops shipped** — `template/motion-systems/backdrop.tsx`, 6 dark / 6 light, frame-driven with zero randomness; defaults are now light `pastel-mesh-flow` / dark `mesh-flow-dark`.
 
 **2026-09-04**
 
-- **Motion system slimmed down** — narration videos keep only one very slow push-in / pull-out camera curve per
-  scene plus the yield lifecycle; subject idle wobble, breathing vignette / light sweep / exposure pulses, camera
-  impulses and x/y/rotation/blur curves are no longer required (template code keeps the capability, off by default).
-  The rest-frame rule changes from "≥2 layers moving" to "camera moving".
-- **Web pages are filmed, not pasted** — a page judged usable during research no longer appears as a static
-  screenshot; the camera "shoots" it: steady scroll (`evidence-scroll-tour`), point-of-interest tour
-  (`stage-keyframe-tour`), magnifier / picture-in-picture (`magnifier-detail` / `pip-zoom-box`), highlighter and
-  ink underline (`highlighter-sweep` / `ink-underline`). Capture spec: Playwright full-page 2× screenshot plus a
-  same-session DOM-measured coordinate JSON that every zoom and underline reads from. → SKILL.md §③,
-  `references/shot-design.md` §2④, `references/broll-sources.md`
+- 🎥 **Motion system slimmed down** — one very slow push / pull camera curve per scene plus the yield lifecycle; idle wobble, breathing and pulses are off by default.
+- 🌐 **Web pages are filmed, not pasted** — pages are shot by the camera (scroll, tour, magnifier, highlighter) instead of appearing as static screenshots, with every coordinate read from Playwright measurements (→ SKILL.md §③, `references/shot-design.md` §2④).
 
 **2026-09-02**
 
-- **Motion workbench `workbench/`** — a CapCut-style post-production desk for finished videos: multi-track timeline,
+- 🎛️ **Motion workbench `workbench/`** — a CapCut-style post-production desk for finished videos: multi-track timeline,
   library (media / motion cards / SFX / backgrounds), schema-driven inspector, live preview and one-click **Export**.
   All 89 motion cards are parameterized (copy, colors, sizes, positions editable; timing vitals stay fixed).
   A narration video can be split into seven kinds of editable units — subtitles / transitions / environment /
@@ -72,13 +53,13 @@ camera moves, plain-cut subtitles, and film-grade SFX, all locked to the voice.
 
   <a href="workbench/GUIDE.md"><img src="workbench/docs/img/01-overview.png" alt="Workbench overview" width="720"></a>
 
-- **Faster renders: shot-segmented master rendering** — `scripts/render_shots.mjs` renders per-shot segments in
+- ⚡ **Faster renders: shot-segmented master rendering** — `scripts/render_shots.mjs` renders per-shot segments in
   parallel (single-process inside each segment to keep rasterization consistent), then concatenates, mixes in the
   full audio track and asserts frame counts; changing one shot re-renders only that segment ± neighbours.
   `scripts/render_stills.mjs` renders batches of stills from a single bundle.
-- **Fewer review tokens** — `scripts/contact_sheet.py` tiles QA frames into 3×4 sheets for the reviewer subagent;
+- 🧮 **Fewer review tokens** — `scripts/contact_sheet.py` tiles QA frames into 3×4 sheets for the reviewer subagent;
   burst triples are extracted only at anchors flagged `"burst": true` (they used to be 2/3 of the review material).
-- **One review round, then deliver** — after the machine gates pass, a single independent review round fixes
+- ✅ **One review round, then deliver** — after the machine gates pass, a single independent review round fixes
   P0/P1 and the video ships; further rounds are opt-in (3 max) instead of "loop until clean".
 
 | Measured (201 s vertical video) | Before | Now |
@@ -88,7 +69,7 @@ camera moves, plain-cut subtitles, and film-grade SFX, all locked to the voice.
 | 43 sampled stills | 11 min | ~1 min |
 | Reviewer reading 160 QA frames | ≈160k tokens / 21 min | ≈40k tokens / 7 min (sheets) |
 
-- New card: community-contributed **douyin-follow-card** ([@scpcn01vision-oss](https://github.com/scpcn01vision-oss)) — 79 cards total.
+- 🤝 New card: community-contributed **douyin-follow-card** ([@scpcn01vision-oss](https://github.com/scpcn01vision-oss)) — 79 cards total.
 
 ## ✨ Highlights
 


### PR DESCRIPTION
## 改了什么
- What's new 十条全部加 emoji（🧩 📐 🎨 🎥 🌐 🎛️ ⚡ 🧮 ✅ 🤝），更显眼。
- 2026-09-05 三条、2026-09-04 两条各收成一句话：删掉筛选过程、缺陷清单、参数细节，保留卡数、路径与两条影响使用的规则（选卡先按素材过滤、卡经验必抄 SHOTBOOK）。
- README_EN.md 同步。
- 09-02 那批（工作台 / 分段渲染 / 评审拼图）保留原文，只加 emoji。

## 规模
README.md −13 行，README_EN.md −19 行。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
