### PR TITLE
shot-at.mjs：按 demo 时钟截帧（seek 减 runStart 且不抑制回调；--play 轮询 getTime）

### DIFF
--- a/demos/_lib/demo-shell.js
+++ b/demos/_lib/demo-shell.js
@@ -356,7 +356,8 @@
       try {
         if (!window.gsap) return;
         var nt = Math.max(0, t) / speed;
-        window.gsap.globalTimeline.time(runStart + nt);
+        // suppressEvents=false：跳过去的 .call() / onUpdate 照常执行，seek 后的中间态才是真的（shot-at.mjs 依赖这一点）
+        window.gsap.globalTimeline.time(runStart + nt, false);
         cueIdx = 0;
         while (cueIdx < cues.length && cues[cueIdx].t / speed < nt) cueIdx++;
       } catch (e) { /* 忽略 */ }

--- a/scripts/shot-at.mjs
+++ b/scripts/shot-at.mjs
@@ -5,12 +5,17 @@
 // 的"鼠标没点到关注上"就是这么漏过去的）。
 //
 // 用法：node scripts/shot-at.mjs <slug> <t> [t ...]        # seek 到各时刻（默认）
-//       node scripts/shot-at.mjs <slug> --play <t> [t ...] # 顺序播放到各时刻
+//       node scripts/shot-at.mjs <slug> --play <t> [t ...] # 重播后顺序播放到各时刻
 // 输出：tools/.verify/<slug>-at<t>.png（--play 时是 -play<t>.png）
 //
-// 两种模式的区别：seek 快，但多条 tween 共写同一个对象时渲染次序不保证
-// （GSAP 的 seek 不重放中间帧），收尾状态可能看着"没到位"；此时用 --play 复核，
-// 那才是观众真正看到的画面。
+// 时钟口径（2026-09-06 修）：两种模式的 t 都是 **demo 秒**（本次 run 内、speed=1）。
+// demo-shell 先加载音效再起跑，run 起点 runStart 不在 globalTimeline 的 0 上——
+// 旧版 seek 直接 `globalTimeline.time(t)`、play 直接按墙钟 sleep，两边各差 0.05~0.8s。
+// 现在 seek 走 `DemoShell.seek(t)`（减掉 runStart、且不抑制回调——.call()/onUpdate 驱动的
+// demo 中间态也刷新），play 走 `DemoShell.replay()` 后轮询 `DemoShell.getTime()` 到 t 再截。
+//
+// 两种模式的区别：seek 快；--play 是观众真正看到的画面（多条 tween 共写一个对象时
+// seek 的渲染次序不保证，收尾状态看着"没到位"时用 --play 复核）。
 import { chromium } from "playwright";
 import { resolve, dirname } from "node:path";
 import { fileURLToPath, pathToFileURL } from "node:url";
@@ -39,26 +44,38 @@ const page = await browser.newPage({ viewport: { width: 1280, height: 800 } });
 const errors = [];
 page.on("pageerror", (e) => errors.push(String(e).slice(0, 200)));
 await page.goto(pathToFileURL(htmlPath).href, { waitUntil: "load", timeout: 15000 });
-await page.waitForTimeout(800);
 
 // 注意：evaluate 传函数 + 参数在本项目的 playwright 版本上会挂住，一律用字符串表达式。
-if (!play) await page.evaluate("(function(){window.gsap.globalTimeline.pause();return 1;})()");
+// 等 demo-shell 起跑（音效表加载完 run() 才执行，runs 计数 ≥1 才有 runStart）
+await page.waitForFunction("document.body && document.body.dataset.runs && window.DemoShell", null, { timeout: 8000 }).catch(() => {});
+const demoTime = () => page.evaluate("(function(){return window.DemoShell ? window.DemoShell.getTime() : window.gsap.globalTimeline.time();})()");
 
-let prev = 0;
+if (play) {
+  // 从头重播，起点即 demo 0 秒；之后按 demo 时钟等，不按墙钟猜
+  await page.evaluate("(function(){window.DemoShell.replay();return 1;})()");
+} else {
+  await page.evaluate("(function(){window.gsap.globalTimeline.pause();return 1;})()");
+}
+
 for (const t of times) {
   if (play) {
-    await page.waitForTimeout(Math.max(0, (t - prev) * 1000));
-    prev = t;
+    const deadline = Date.now() + (t + 6) * 1000;
+    // eslint-disable-next-line no-constant-condition
+    while (true) {
+      const now = Number(await demoTime());
+      if (now >= t || Date.now() > deadline) break;
+      await page.waitForTimeout(Math.min(40, Math.max(5, (t - now) * 1000)));
+    }
   } else {
-    // 首播 runStart ≈ 0，所以 globalTimeline.time() 就是 demo 秒，不加偏移
-    await page.evaluate(`(function(){window.gsap.globalTimeline.time(${t});return 1;})()`);
+    // DemoShell.seek 已减 runStart，且以 suppressEvents=false 渲染——中途的 .call()/onUpdate 都会执行
+    await page.evaluate(`(function(){window.DemoShell.seek(${t});return 1;})()`);
     await page.waitForTimeout(180);
   }
-  const clock = await page.evaluate("(function(){return window.gsap.globalTimeline.time();})()");
+  const clock = Number(await demoTime());
   const tag = String(t).replace(".", "_");
   const file = resolve(outDir, `${slug}-${play ? "play" : "at"}${tag}.png`);
   await page.screenshot({ path: file, animations: "allow", timeout: 8000 });
-  console.log(`t=${t} (clock=${Number(clock).toFixed(2)}) → tools/.verify/${slug}-${play ? "play" : "at"}${tag}.png`);
+  console.log(`t=${t} (clock=${clock.toFixed(2)}) → tools/.verify/${slug}-${play ? "play" : "at"}${tag}.png`);
 }
 if (errors.length) console.error("页面错误：" + JSON.stringify(errors));
 await browser.close();


### PR DESCRIPTION
## scripts/shot-at.mjs：按 demo 时钟截帧

独立评审 PR #14 时发现的工具口径问题（P2-9），用户要求另开小修：

- **seek 模式**：旧版直接 `globalTimeline.time(t)`，但 demo-shell 现在先加载音效表再 `run()`，run 起点 `runStart` 不在 0 上 → 截图滞后 0.05~0.1s；且 GSAP seek 默认抑制回调，`.call()` / `onUpdate` 驱动的 demo（title-demote / source-converge / line-carry / freeze / unit-grid 计数等）中间态不刷新。现在走 `DemoShell.seek(t)`，`demo-shell.js` 的 seek 改为 `time(runStart + nt, false)`——回调照常执行。
- **--play 模式**：旧版按墙钟 sleep，实际 clock = t + ≈0.83s（页面加载 + 800ms）。现在先 `DemoShell.replay()` 再轮询 `DemoShell.getTime()` 到 t 才截。
- 两种模式打印的 `clock` 统一为 demo 秒（本次 run 内、speed=1）。

实测：`number-counter` seek 1.0 / 2.0 → clock 1.00 / 2.00；`--play` 1.0 / 2.0 → 1.05 / 2.04；`split-compare-slider`（onUpdate 驱动）seek 1.5 中间态渲染正确。
`demo-shell.js` 的改动只影响 `DemoShell.seek`（配音台与本脚本用），普通 demo 播放路径不变。与 PR #14 无文件重叠。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
