### PR TITLE
首镜验效：render_shots --preview-dir 单镜有声预览 + SKILL.md ⑥-1.5 先渲第一镜再问整片还是逐镜

### DIFF
--- a/SKILL.md
+++ b/SKILL.md
@@ -217,6 +217,20 @@ cd remotion && python3 ../scripts/freeze_probe.py --shots shots.json          # 
 node <skill根>/scripts/render_stills.mjs --times 2.0,7.2,...   # 抽样点=每镜入/出+关键锚点+状态切换窗
 ```
 
+**⑥-1.5 首镜验效 · 定渲染节奏**（2026-09-07 用户定版，母版首渲的必经关——**首渲禁止直接 `--all`**）：
+```bash
+# 在工程 remotion/ 目录下：只渲第一镜 + 整条音轨，出一条有声单镜预览
+node <skill根>/scripts/render_shots.mjs --shots shots.json --only s01 \
+     --audio out/full-mix.wav --preview-dir out/preview
+open out/preview/s01.mp4        # 打开给用户看
+```
+第一镜是全片的样板（蒙皮 / 字幕样式 / 相机幅度 / 音效电平），它不对整片就都不对——预览有问题先修再问节奏。
+用户看过后**问一次**（AskUserQuestion 类工具，两个选项，不替用户决定）：
+1. **整片渲**：⑥-2 的 `--all --parallel 4 --concat … --audio … --mux …`（s01 段与音轨走缓存，不重渲）；
+2. **逐镜节奏**：`--only s02 --audio … --preview-dir out/preview` 渲一镜、开给用户看一镜、等用户说"继续 / 改"再下一镜，
+   改动用 `--changed sNN`；全部看完再 `--concat + --mux` 拼装。
+两种节奏最后都要过 ⑥-2 的帧数断言与 ⑦ 三重验收——逐镜模式下"用户看过"不等于"验收过"，机器闸与独立审片照做。
+
 **⑥-2 分段渲染母版制**——按镜头切段、段内单进程连续渲（段内光栅自洽；多 tab 并发会产生周期性相位抖动），
 段间 `--parallel 4` 实测比单进程快 1.3~1.8×（本机负载不同两次分别 253→139s、307→230s，4 镜 900 帧）；
 整条音轨没有光栅问题，`--audio-concurrency 4`（默认）实测 419s→175s（116s 片），`imageFormat:'none'` 只省 6%——浏览器逐帧 seek 才是音轨渲染的主成本；
@@ -331,5 +345,5 @@ X [`@VincentWei93`](https://x.com/VincentWei93) ·
 | 字级时间戳（本机 CPU） | `scripts/timestamps_cpu.py`（FireRedASR2-CTC 默认 / faster-whisper 备选，+ 口播稿逐字对齐）→ `scripts/make_timing.py` |
 | **闸报 FAIL 了怎么办 · 怎么少烧母版** | ⑥⑦「迭代纪律」三条——先读闸怎么量的再改 · 静帧优先 · 改哪段渲哪段、复审改动攒批 |
 | 机器闸（画面健康 / 保真 / 词落点+镜尾 / 音效） | `scripts/motion_check.py`（静止段+并发光栅抖动双判定）/ `scripts/card_lint.py`（卡片须复制自 template/cards）/ `scripts/beat_lint.py`（词落点对 timestamps + `--shots` 镜尾保护带）/ `scripts/sfx_check.py`（solo 在场 + `--mix` 可听度） |
-| 渲染提速（分段母版 / 批量静帧 / 空台预检 / 评审拼图） | `scripts/render_shots.mjs`（段渲+拼装+音轨混入+帧数断言；`--changed sNN` 单镜头迭代 53s）/ `scripts/render_stills.mjs`（一次 bundle 批量 still）/ `scripts/beat_gap_check.py`（渲染前空台预检）/ `scripts/contact_sheet.py`（QA 帧拼 3×4 网格） |
+| 渲染提速（分段母版 / 批量静帧 / 空台预检 / 评审拼图）· 首镜验效 | `scripts/render_shots.mjs`（段渲+拼装+音轨混入+帧数断言；`--changed sNN` 单镜头迭代 53s；`--only s01 --preview-dir` 有声单镜预览 → ⑥-1.5 问用户整片还是逐镜）/ `scripts/render_stills.mjs`（一次 bundle 批量 still）/ `scripts/beat_gap_check.py`（渲染前空台预检）/ `scripts/contact_sheet.py`（QA 帧拼 3×4 网格） |
 | 动效配套音效 | 逐卡 cue 表 `demos/_lib/sfx-map.js`（口味纪律见 `references/demo-spec.md`「Demo 硬性要求」第 8 条）；制作端 `node scripts/sfx_dump.mjs` 导出采样 |

--- a/scripts/render_shots.mjs
+++ b/scripts/render_shots.mjs
@@ -22,6 +22,8 @@
 //        [--audio out/full-mix.wav] [--force-audio]        # 整条音轨（缓存过时长+指纹校验才复用）
 //        [--audio-concurrency 4]                           # 音轨渲染并发 tab 数（音轨无光栅问题，不受视频段单并发纪律约束）
 //        [--mux out/preview.mp4]                           # assembled + audio → 有声预览
+//        [--preview-dir out/preview]                        # 本次渲的每一段各出一条有声单镜预览 <dir>/<id>.mp4（段视频 + 整条音轨对应区间），
+//                                                           #   配 --only s01 + --audio 用：首镜验效 / 逐镜节奏（SKILL.md ⑥-1.5），不必等整片拼装
 //        [--props '{"k":1}' | --props @props.json]         # 合成 inputProps（工作台 Main 等吃工程 JSON 的合成必须给）
 //        [--public-dir .render-public]                     # 覆盖 public/（Remotion 静态服务器拒绝符号链接素材时先解引用同步）
 //        [--image-format png|jpeg] [--jpeg-quality 95] [--crf 18]   # 中间帧/编码：覆盖 remotion.config.ts；不给则读配置，配置没设用 Remotion 默认（JPEG-80）
@@ -296,6 +298,24 @@ if (audioOut) {
     console.log(`audio → ${audioOut}  ${got} 帧  ${((Date.now() - st) / 1000).toFixed(0)}s ✓`);
   } else {
     console.log(`audio 复用缓存 ${audioOut}（时长 + 素材/props/时序配置指纹均未变；${fp.nAssets} 个音频文件、${fp.nTiming} 个时序配置文件在册——指纹看不见的改动请 --force-audio）`);
+  }
+}
+
+// —— 单镜有声预览（SKILL.md ⑥-1.5 首镜验效 / 逐镜节奏）：本次渲的每段 + 整条音轨的对应区间 → <preview-dir>/<id>.mp4 ——
+//   音轨仍整条渲一次（纪律 A 不破），预览只是从整条里按段边界裁一刀；帧边界与段表同一 Math.round 规则（纪律 B）
+const previewDir = opt('preview-dir', null);
+if (previewDir) {
+  if (!audioOut) { console.error('--preview-dir 需要同时给 --audio（单镜预览的声音从整条音轨裁）'); process.exit(2); }
+  if (!todo.length) console.warn('--preview-dir：本次没有渲任何段（缓存全在）——要出预览请配 --only <id>');
+  fs.mkdirSync(previewDir, {recursive: true});
+  for (const seg of todo) {
+    const out = path.join(previewDir, `${seg.id}.mp4`);
+    execFileSync('ffmpeg', ['-y', '-v', 'error', '-i', seg.file,
+      '-ss', (seg.from / fps).toFixed(6), '-t', (seg.frames / fps).toFixed(6), '-i', audioOut,
+      '-map', '0:v', '-map', '1:a', '-c:v', 'copy', '-c:a', 'aac', '-b:a', '256k', '-shortest', out]);
+    const got = probeFrames(out);
+    if (got !== seg.frames) { console.error(`FAIL: 预览 ${seg.id} 帧数 ${got} != ${seg.frames}`); process.exit(1); }
+    console.log(`preview → ${out}  ${seg.id} 帧 ${seg.from}-${seg.to} + 音轨 ${(seg.from / fps).toFixed(2)}s 起 ${(seg.frames / fps).toFixed(2)}s ✓`);
   }
 }
 


### PR DESCRIPTION
## 动机
用户 2026-09-07 定版：**先渲染第一个镜头让用户查验效果，再询问用户是否渲染完整的，还是按一个镜头一个镜头的节奏来做。** 现有 `render_shots.mjs` 只能 `--only sNN` 渲出 muted 段，有声预览要等 `--concat + --mux` 整片拼装，第一镜没法单独带声音给用户看。

## 改了什么
- **`scripts/render_shots.mjs` 新增 `--preview-dir <dir>`**：本次渲的每一段各出一条有声预览 `<dir>/<id>.mp4` = 段视频 + 整条音轨按段边界裁出的对应区间。音轨仍整条渲一次（纪律 A 不破），裁切边界与段表同一 `Math.round` 规则（纪律 B），预览帧数断言（纪律 C）。需配 `--audio`；本次没渲任何段时提示配 `--only`。
- **SKILL.md ⑥-1.5 首镜验效 · 定渲染节奏**：首渲禁止直接 `--all`。`--only s01 --audio --preview-dir` → 打开给用户看 → 用 AskUserQuestion 类工具问一次：整片渲（s01 段与音轨走缓存）还是逐镜节奏（每镜渲完开给用户、等用户说继续 / 改，改动 `--changed sNN`，最后拼装）。两种节奏最后都过 ⑥-2 帧数断言与 ⑦ 三重验收——"用户看过"不等于"验收过"。第一镜是全片样板，预览有问题先修再问节奏。目录路由同步。

## 验证
test03 工程（23 镜 5777 帧）：`--only s01_hook --audio out/full-mix.wav --preview-dir out/preview` → 51s（段 47s + 音轨复用缓存），出 `s01_hook.mp4` h264 + aac 11.37s，341 帧断言通过。`node --check` 通过。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
