### PR TITLE
fix: validate shot selection before render initialization

### DIFF
--- a/scripts/render_shots.mjs
+++ b/scripts/render_shots.mjs
@@ -50,6 +50,13 @@ const opt = (name, dflt) => {
   return v;
 };
 const has = (name) => args.includes(`--${name}`);
+const selectionFlags = ['all', 'changed', 'only'].filter(has);
+if (selectionFlags.length > 1) {
+  console.error(`--all、--changed、--only 互斥，只能指定一个渲染范围（收到：${selectionFlags.map((name) => `--${name}`).join(', ')}）`);
+  process.exit(2);
+}
+const changedId = opt('changed', null);
+const onlyIds = has('only') ? opt('only', null).split(',') : null;
 const projDir = process.cwd();
 const entry = opt('entry', 'src/entry.ts');
 const shotsPath = opt('shots', 'shots.json');
@@ -61,10 +68,6 @@ if (!Number.isInteger(parallel) || parallel < 1) {   // NaN→0 个 worker 会�
   console.error(`--parallel 需为 ≥1 的整数，得到：${opt('parallel', '4')}`);
   process.exit(2);
 }
-
-const require = createRequire(path.join(projDir, 'package.json'));
-const {bundle} = require('@remotion/bundler');
-const {selectComposition, renderMedia, getCompositions} = require('@remotion/renderer');
 
 const shots = JSON.parse(fs.readFileSync(shotsPath, 'utf8'));
 if (!Array.isArray(shots) || !shots.length ||
@@ -92,6 +95,28 @@ for (let i = 1; i < shots.length; i++) {
     process.exit(1);
   }
 }
+
+// 渲染范围只依赖镜头表，先校验再加载 Remotion / 打包 / 启动浏览器。
+const changedIndex = changedId === null ? -1 : shots.findIndex((s) => s.id === changedId);
+if (changedId !== null && changedIndex < 0) {
+  console.error(`--changed 只接受一个已知镜头 id，未找到：${changedId || '（空）'}；批量选段请用 --only 并显式包含受影响的邻镜`);
+  process.exit(2);
+}
+if (onlyIds !== null) {
+  const unknownIds = onlyIds.filter((id) => !shots.some((s) => s.id === id));
+  if (unknownIds.length) {
+    console.error(`--only 里有未知镜头 id：${unknownIds.map((id) => id || '（空）').join(', ')}`);
+    process.exit(2);
+  }
+  if (new Set(onlyIds).size !== onlyIds.length) {
+    console.error(`--only 镜头 id 重复：${onlyIds.join(', ')}`);
+    process.exit(2);
+  }
+}
+
+const require = createRequire(path.join(projDir, 'package.json'));
+const {bundle} = require('@remotion/bundler');
+const {selectComposition, renderMedia, getCompositions} = require('@remotion/renderer');
 
 const t0 = Date.now();
 // 必须带上工程 remotion.config.ts 里的 webpack alias / publicDir 等（bundle() 自己不读配置文件，评审 P1）
@@ -145,16 +170,11 @@ for (let i = 0; i < segs.length; i++) {
 // —— 选段 ——
 let todo;
 if (has('all')) todo = segs;
-else if (opt('changed', null)) {
-  const id = opt('changed');
-  const k = segs.findIndex((s) => s.id === id);
-  if (k < 0) { console.error(`未找到镜头 ${id}`); process.exit(2); }
+else if (changedId !== null) {
   // 镜头衔接的 lead/tail 交叠会波及邻镜边缘几帧 → 邻段一并重渲
-  todo = segs.slice(Math.max(0, k - 1), Math.min(segs.length, k + 2));
-} else if (opt('only', null)) {
-  const ids = opt('only').split(',');
-  todo = segs.filter((s) => ids.includes(s.id));
-  if (todo.length !== ids.length) { console.error('--only 里有未知镜头 id'); process.exit(2); }
+  todo = segs.slice(Math.max(0, changedIndex - 1), Math.min(segs.length, changedIndex + 2));
+} else if (onlyIds !== null) {
+  todo = segs.filter((s) => onlyIds.includes(s.id));
 } else {
   todo = segs.filter((s) => !fs.existsSync(s.file));
 }

--- a/scripts/render_shots.test.mjs
+++ b/scripts/render_shots.test.mjs
@@ -1,0 +1,136 @@
+import assert from 'node:assert/strict';
+import {spawnSync} from 'node:child_process';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import {fileURLToPath} from 'node:url';
+import test from 'node:test';
+
+const script = fileURLToPath(new URL('./render_shots.mjs', import.meta.url));
+const shotIds = ['s01', 's02', 's03', 's04', 's05'];
+
+// Exercise the real CLI. Invalid input needs no Remotion installation; valid
+// selection uses lightweight renderer/ffprobe doubles, not a browser or video.
+function project(t, {renderer = false, cached = []} = {}) {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'talkcraft-selection-'));
+  t.after(() => fs.rmSync(root, {recursive: true, force: true}));
+  const write = (file, text) => {
+    const dest = path.join(root, file);
+    fs.mkdirSync(path.dirname(dest), {recursive: true});
+    fs.writeFileSync(dest, text);
+  };
+  write('package.json', '{}');
+  write('shots.json', JSON.stringify(shotIds.map((id, i) => ({id, start: i, end: i + 1}))));
+  for (const id of cached) write(`out/segments/${id}.mp4`, JSON.stringify({frames: 30}));
+
+  const traceFile = path.join(root, 'trace.jsonl');
+  if (renderer) {
+    const trace = `const fs = require('node:fs');
+      const trace = (event) => fs.appendFileSync(process.env.TALKCRAFT_TEST_TRACE, JSON.stringify(event) + '\\n');`;
+    write('node_modules/@remotion/bundler/index.js', `${trace}
+      trace({event: 'load-bundler'});
+      exports.bundle = async () => {trace({event: 'bundle'}); return 'test-bundle';};`);
+    write('node_modules/@remotion/renderer/index.js', `${trace}
+      const path = require('node:path');
+      trace({event: 'load-renderer'});
+      const composition = {id: 'Test', fps: 30, durationInFrames: 150, width: 1080, height: 1920};
+      exports.getCompositions = async () => [composition];
+      exports.selectComposition = async () => composition;
+      exports.renderMedia = async (options) => {
+        trace({event: 'render', id: path.basename(options.outputLocation).replace('.rendering.mp4', ''),
+          frameRange: options.frameRange, codec: options.codec, muted: options.muted, concurrency: options.concurrency});
+        fs.writeFileSync(options.outputLocation, JSON.stringify({frames: options.frameRange[1] - options.frameRange[0] + 1}));
+      };`);
+    write('bin/ffprobe', `#!/usr/bin/env node
+      const fs = require('node:fs');
+      console.log(JSON.parse(fs.readFileSync(process.argv.at(-1), 'utf8')).frames);`);
+    fs.chmodSync(path.join(root, 'bin/ffprobe'), 0o755);
+  }
+
+  return {
+    root,
+    run(args) {
+      return spawnSync(process.execPath, [script, ...args], {
+        cwd: root,
+        encoding: 'utf8',
+        timeout: 10000,
+        env: {...process.env, TALKCRAFT_TEST_TRACE: traceFile,
+          PATH: [path.join(root, 'bin'), path.dirname(process.execPath), process.env.PATH].join(path.delimiter)},
+      });
+    },
+    trace() {
+      return fs.existsSync(traceFile)
+        ? fs.readFileSync(traceFile, 'utf8').trim().split('\n').map((line) => JSON.parse(line))
+        : [];
+    },
+  };
+}
+
+const invalid = [
+  ['all and only', ['--all', '--only', 's02'], /互斥/],
+  ['only and all', ['--only', 's02', '--all'], /互斥/],
+  ['all and changed', ['--all', '--changed', 's02'], /互斥/],
+  ['only and changed', ['--only', 's01', '--changed', 's02'], /互斥/],
+  ['all three modes', ['--all', '--only', 's01', '--changed', 's02'], /互斥/],
+  ['missing only value', ['--only'], /--only 缺参数值/],
+  ['missing changed value', ['--changed', '--parallel', '2'], /--changed 缺参数值/],
+  ['unknown only ID', ['--only', 's01,missing'], /--only.*missing/],
+  ['unknown changed ID', ['--changed', 'missing'], /--changed.*missing/],
+  ['changed list', ['--changed', 's01,s03'], /--changed.*一个.*--only.*邻镜/],
+  ['duplicate only ID', ['--only', 's01,s01'], /--only.*重复/],
+  ['empty only ID', ['--only', 's01,'], /--only.*空/],
+  ['empty only value', ['--only', ''], /--only.*空/],
+  ['empty changed value', ['--changed', ''], /--changed.*一个/],
+];
+
+for (const [name, args, message] of invalid) {
+  test(`rejects ${name} before loading Remotion`, (t) => {
+    const fixture = project(t);
+    const result = fixture.run(args);
+    assert.ifError(result.error);
+    assert.equal(result.status, 2, result.stderr);
+    assert.match(result.stderr, message);
+    assert.doesNotMatch(result.stderr, /MODULE_NOT_FOUND/);
+    assert.equal(fs.existsSync(path.join(fixture.root, 'out')), false);
+  });
+}
+
+test('rejects conflicting modes before reading project files', (t) => {
+  const fixture = project(t);
+  fs.unlinkSync(path.join(fixture.root, 'shots.json'));
+  const result = fixture.run(['--all', '--only', 's02']);
+  assert.ifError(result.error);
+  assert.equal(result.status, 2, result.stderr);
+  assert.match(result.stderr, /互斥/);
+});
+
+const valid = [
+  ['all including cached segments', ['--all'], ['s02'], shotIds],
+  ['single only', ['--only', 's03'], shotIds, ['s03']],
+  ['multiple only in timeline order', ['--only', 's04,s02'], shotIds, ['s02', 's04']],
+  ['changed with both neighbors', ['--changed', 's03'], shotIds, ['s02', 's03', 's04']],
+  ['changed first shot', ['--changed', 's01'], shotIds, ['s01', 's02']],
+  ['changed last shot', ['--changed', 's05'], shotIds, ['s04', 's05']],
+  ['default missing segments', [], ['s01', 's03', 's05'], ['s02', 's04']],
+  ['default complete cache', [], shotIds, []],
+];
+
+for (const [name, args, cached, expected] of valid) {
+  test(`preserves ${name}`, (t) => {
+    const fixture = project(t, {renderer: true, cached});
+    const result = fixture.run(args);
+    assert.ifError(result.error);
+    assert.equal(result.status, 0, result.stderr);
+    const events = fixture.trace();
+    assert.equal(events.filter((event) => event.event === 'bundle').length, 1);
+    const renders = events.filter((event) => event.event === 'render');
+    assert.deepEqual(renders.map((event) => event.id), expected);
+    for (const render of renders) {
+      const index = shotIds.indexOf(render.id);
+      assert.deepEqual(render.frameRange, [index * 30, (index + 1) * 30 - 1]);
+      assert.equal(render.codec, 'h264');
+      assert.equal(render.muted, true);
+      assert.equal(render.concurrency, 1);
+    }
+  });
+}


### PR DESCRIPTION
`render_shots.mjs` 同时收到 `--all` 与 `--only` / `--changed` 时，原先会静默按 `--all` 渲染全片；未知镜头 ID 等参数错误也要等 Remotion 加载和工程打包后才报错。

本次将渲染范围校验移到 Remotion 初始化前：三种模式互斥，提前检查必填值、镜头 ID 及 `--only` 的空项和重复项。`--changed` 的错误提示同时说明，批量显式选段需包含受影响邻镜。合法的单镜、批量选镜、邻镜重渲和默认缺失缓存模式保持原有行为。

新增 23 项 CLI 回归测试：非法参数在未安装 Remotion 的临时工程中验证提前退出；合法选段使用轻量 Remotion / ffprobe 替身核对渲染范围、帧边界及渲染参数。本次未进行实际视频渲染。

验证通过：

- `node --test --test-reporter=spec scripts/render_shots.test.mjs`：23 / 23 通过。
- `node --check scripts/render_shots.mjs`
- `node --check scripts/render_shots.test.mjs`
- `git diff --check`